### PR TITLE
Rewrite XQuery injection to use an additional taint step instead of multiple configurations

### DIFF
--- a/java/ql/src/Security/CWE/CWE-652/XQueryInjectionLib.qll
+++ b/java/ql/src/Security/CWE/CWE-652/XQueryInjectionLib.qll
@@ -1,7 +1,4 @@
 import java
-import semmle.code.java.dataflow.FlowSources
-import semmle.code.java.dataflow.TaintTracking2
-import DataFlow::PathGraph
 
 /** A call to `XQConnection.prepareExpression`. */
 class XQueryParserCall extends MethodAccess {
@@ -14,77 +11,25 @@ class XQueryParserCall extends MethodAccess {
       m.hasName("prepareExpression")
     )
   }
-  /** Returns the first parameter of the `bindString` method. */
+
+  /**
+   * Returns the first parameter of the `prepareExpression` method, which provides
+   * the string, stream or reader to be compiled into a prepared expression.
+   */
   Expr getInput() { result = this.getArgument(0) }
 }
 
-/** A call to `XQDynamicContext.bindString`. */
-class XQueryBindStringCall extends MethodAccess {
-  XQueryBindStringCall() {
-    exists(Method m |
-      this.getMethod() = m and
-      m.getDeclaringType()
-          .getASourceSupertype*()
-          .hasQualifiedName("javax.xml.xquery", "XQDynamicContext") and
-      m.hasName("bindString")
+/** A call to `XQPreparedExpression.executeQuery`. */
+class XQueryExecuteCall extends MethodAccess {
+  XQueryExecuteCall() {
+    exists(Method m | this.getMethod() = m and
+    m.hasName("executeQuery") and
+    m.getDeclaringType()
+        .getASourceSupertype*()
+        .hasQualifiedName("javax.xml.xquery", "XQPreparedExpression")
     )
   }
-  /** Returns the second parameter of the `bindString` method. */
-  Expr getInput() { result = this.getArgument(1) }
-}
 
-/** Used to determine whether to call the `prepareExpression` method, and the first parameter value can be remotely controlled. */
-class ParserParameterRemoteFlowConf extends TaintTracking2::Configuration {
-  ParserParameterRemoteFlowConf() { this = "ParserParameterRemoteFlowConf" }
-
-  override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node sink) {
-    exists(XQueryParserCall xqpc | xqpc.getSink() = sink.asExpr())
-  }
-}
-
-/** Used to determine whether to call the `bindString` method, and the second parameter value can be controlled remotely. */
-class BindParameterRemoteFlowConf extends TaintTracking2::Configuration {
-  BindParameterRemoteFlowConf() { this = "BindParameterRemoteFlowConf" }
-
-  override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node sink) {
-    exists(XQueryBindStringCall xqbsc | xqbsc.getSink() = sink.asExpr())
-  }
-}
-
-/**
- * A data flow source for XQuery injection vulnerability.
- *  1. `prepareExpression` call as sink.
- *  2. Determine whether the `var1` parameter of `prepareExpression` method can be controlled remotely.
- */
-class XQueryInjectionSource extends DataFlow::ExprNode {
-  XQueryInjectionSource() {
-    exists(MethodAccess ma, Method m, ParserParameterRemoteFlowConf conf, DataFlow::Node node |
-      m = ma.getMethod()
-    |
-      m.hasName("prepareExpression") and
-      m.getDeclaringType()
-          .getASourceSupertype*()
-          .hasQualifiedName("javax.xml.xquery", "XQConnection") and
-      asExpr() = ma and
-      node.asExpr() = ma.getArgument(0) and
-      conf.hasFlowTo(node)
-    )
-  }
-}
-
-/** A data flow sink for XQuery injection vulnerability. */
-class XQueryInjectionSink extends DataFlow::Node {
-  XQueryInjectionSink() {
-    exists(MethodAccess ma, Method m | m = ma.getMethod() |
-      m.hasName("executeQuery") and
-      m.getDeclaringType()
-          .getASourceSupertype*()
-          .hasQualifiedName("javax.xml.xquery", "XQPreparedExpression") and
-      asExpr() = ma.getQualifier()
-    )
-  }
+  /** Return this prepared expression. */
+  Expr getPreparedExpression() { result = this.getQualifier() }
 }


### PR DESCRIPTION
Also remove a needless barrier -- the `bindString` method doesn't conduct taint by default, so excluding particular instances of that call is not necessary.

I also switched from a DataFlow::Configuration, which requires that precisely the same user-controlled string is maintained, to a TaintTracking::Configuration, which allows things such as concatenating strings, storing and retrieving from maps, and other operations that preserve the property "this is potentially under user control" but perhaps not the precise value.

The next step is to add tests -- you will need to add a directory under `ql/test/experimental` and create test cases -- see other directories under there for examples; ask if there is anything not clear about how the tests are structured. Use `codeql test run` to evaluate test cases, and to generate `.actual` files indicating your query's result in the same format as the `.expected` files use to validate them.